### PR TITLE
Fix license check

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -117,10 +117,10 @@ function prb() {
 }
 
 function ensure_license() {
-	if [ ! -f licenses-accepted ]; then
-		# Prepare the SDK license
-		prepare_sdk_license
+	# Prepare the SDK license
+	prepare_sdk_license
 
+	if [ ! -f licenses-accepted ]; then
 		# Show the message
 		echo "###############################################################"
 		prb "Please read the following two license terms:"


### PR DESCRIPTION
If the script is never run without the `licenses-accepted` arg it won't download the `winsdksetup.exe`